### PR TITLE
s/babel-core/babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "babel-node ./server.js"
   },
   "devDependencies": {
-    "babel-core": "5.8.22",
+    "babel": "5.8.21",
     "babel-eslint": "^4.0.5",
     "babel-loader": "5.3.2",
     "babel-runtime": "5.8.20",


### PR DESCRIPTION
The examples use `babel-node` which is provided by the `babel` npm package.
