### PR TITLE
Simplify schema retrieval

### DIFF
--- a/build/babelGraphQLPlugin.js
+++ b/build/babelGraphQLPlugin.js
@@ -1,9 +1,4 @@
-var fs = require('fs');
 var getBabelGraphQLPlugin = require('babel-relay-plugin');
-var path = require('path');
-
-var SCHEMA_PATH = path.resolve(__dirname, '../data/schema.json');
-
-var schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+var schema = require('../data/schema.json');
 
 module.exports = getBabelGraphQLPlugin(schema.data);


### PR DESCRIPTION
`require` knows how to load JSON files, so lets use that instead of `fs` and `JSON.parse` :smile: 
