### PR TITLE
Add 'npm run update-schema' shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If at any time you make changes to `data/schema.js`, stop the server,
 regenerate `data/schema.json`, and restart the server:
 
 ```
-./scripts/updateSchema.js
+npm run update-schema
 npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "facebook/relay-starter-kit",
   "version": "0.1.0",
   "scripts": {
-    "start": "babel-node ./server.js"
+    "start": "babel-node ./server.js",
+    "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "devDependencies": {
     "babel": "5.8.21",


### PR DESCRIPTION
Running './scripts/updateSchema.js' only works if you have babel-node installed globally.
'npm run', on the other hand, automatically includes installed node modules in the PATH.
