### PR TITLE
Don't expose the entire node_modules directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,8 @@ var app = new WebpackDevServer(compiler, {
 });
 // Serve static resources
 app.use('/', express.static('public'));
-app.use('/node_modules', express.static('node_modules'));
+app.use('/node_modules/react', express.static('node_modules/react'));
+app.use('/node_modules/react-relay', express.static('node_modules/react-relay'));
 app.listen(APP_PORT, () => {
   console.log(`App is now running on http://localhost:${APP_PORT}`);
 });


### PR DESCRIPTION
I think the problem with this being a "starter kit" is that people are going to think it's a good-practice starting point for building their own app.

Then they install some private npm modules... and voila, their intellectual property, exposed to the world!

From what I can tell, it's only react and relay that need to be exposed here, so this PR ensures only those two modules are exposed
