### PR TITLE
Move express from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "eslint": "^1.0.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.0",
-    "express": "^4.13.1",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
     "classnames": "^2.1.3",
+    "express": "^4.13.1",
     "express-graphql": "^0.1.0",
     "graphql": "^0.2.6",
     "graphql-relay": "^0.1.0",


### PR DESCRIPTION
`express` should be a `dependency` instead of devDependency because it's used by server.
