### PR TITLE
remove path variable from route

### DIFF
--- a/js/routes/AppHomeRoute.js
+++ b/js/routes/AppHomeRoute.js
@@ -1,5 +1,4 @@
 export default class extends Relay.Route {
-  static path = '/';
   static queries = {
     viewer: (Component) => Relay.QL`
       query {


### PR DESCRIPTION
I think this variable is no longer necessary?  When first approaching relay, i found it confusing because it made the Route appear to be related to url routing.
