### PR TITLE
Update express-graphql to fix a dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-relay-plugin": "0.1.3",
     "classnames": "^2.1.3",
     "express": "^4.13.1",
-    "express-graphql": "^0.1.0",
+    "express-graphql": "0.3.0",
     "graphql": "0.4.2",
     "graphql-relay": "0.3.1",
     "react": "^0.14.0-beta3",


### PR DESCRIPTION
`npm install` was failing because express-graphql depended on an older version of graphql-js:
`EPEERINVALID express-graphql@0.1.1 requires a peer of graphql@~0.2.6 but none was installed.`
