### PR TITLE
Bundle GraphiQL with the starter kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-relay-plugin": "0.1.3",
     "classnames": "^2.1.3",
     "express": "^4.13.1",
-    "express-graphql": "^0.1.0",
+    "express-graphql": "0.3.0",
     "graphql": "0.4.2",
     "graphql-relay": "0.3.1",
     "react": "^0.14.0-beta3",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "react-relay": "^0.1.0",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
+  },
+  "devDependencies": {
+    "graphiql": "^0.1.1",
+    "whatwg-fetch": "^0.9.0"
   }
 }

--- a/public/graphiql/index.html
+++ b/public/graphiql/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/node_modules/graphiql/graphiql.css" />
+    <script src="/node_modules/react/dist/react.min.js"></script>
+    <script src="/node_modules/whatwg-fetch/fetch.js"></script>
+    <script src="/node_modules/graphiql/graphiql.min.js"></script>
+  </head>
+  <body>
+    <div id="root" style="width: 100%; height: 100%">Loading...</div>
+    <script>
+      function graphQLFetcher(graphQLParams) {
+        return fetch(window.location.origin + '/graphql', {
+          method: 'post',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(graphQLParams),
+        }).then(function (response) {
+          return response.json();
+        });
+      }
+      React.render(React.createElement(GraphiQL, { fetcher: graphQLFetcher }),
+        document.getElementById('root')
+      );
+    </script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -39,6 +39,9 @@ var app = new WebpackDevServer(compiler, {
 app.use('/', express.static('public'));
 app.use('/node_modules/react', express.static('node_modules/react'));
 app.use('/node_modules/react-relay', express.static('node_modules/react-relay'));
+app.use('/node_modules/whatwg-fetch', express.static('node_modules/whatwg-fetch'));
+app.use('/node_modules/graphiql', express.static('node_modules/graphiql'));
 app.listen(APP_PORT, () => {
   console.log(`App is now running on http://localhost:${APP_PORT}`);
+  console.log(`and GraphiQL running on http://localhost:${APP_PORT}/graphiql/`);
 });


### PR DESCRIPTION
Make the experience of starting with Relay and GraphQL smoother by including GraphiQL in the development server out of the box.

GraphiQL is installed as a dev dependency and can be accessed on http://localhost:3000/graphiql

Note: npm currently complains about the React peer dependency. This is going to be fixed by https://github.com/graphql/graphiql/pull/14
