### PR TITLE
Use streamlined route queries

### DIFF
--- a/js/routes/AppHomeRoute.js
+++ b/js/routes/AppHomeRoute.js
@@ -1,10 +1,8 @@
 export default class extends Relay.Route {
   static queries = {
-    viewer: (Component) => Relay.QL`
+    viewer: () => Relay.QL`
       query {
-        viewer {
-          ${Component.getFragment('viewer')},
-        },
+        viewer
       }
     `,
   };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "graphql": "0.4.2",
     "graphql-relay": "0.3.1",
     "react": "^0.14.0-beta3",
-    "react-relay": "^0.1.0",
+    "react-relay": "^0.2.1",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   }


### PR DESCRIPTION
Bumps the react-relay dependency to 0.2.1+ so that we can use
streamlined route queries (https://github.com/facebook/relay/pull/115).

Test plan: `npm start` and visit http://localhost:3000/; see that
widgets list still works.
