### PR TITLE
Upgrade relay-starter-kit to use Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
   "presets": ["es2015", "stage-0", "react"]
 }
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 npm-debug.log
 data/schema.graphql
+.idea/

--- a/data/schema.json
+++ b/data/schema.json
@@ -999,7 +999,7 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description": "A Directives provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "name",

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-import 'babel/polyfill';
+import 'babel-polyfill';
 
 import App from './components/App';
 import AppHomeRoute from './routes/AppHomeRoute';

--- a/package.json
+++ b/package.json
@@ -9,18 +9,22 @@
     "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
-    "babel": "5.8.21",
-    "babel-loader": "5.3.2",
-    "babel-relay-plugin": "^0.4.1",
-    "classnames": "^2.1.3",
-    "express": "^4.13.1",
-    "express-graphql": "^0.4.4",
-    "graphql": "^0.4.7",
-    "graphql-relay": "^0.3.3",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "react-relay": "^0.5.0",
-    "webpack": "^1.12.4",
-    "webpack-dev-server": "^1.10.1"
+    "babel-core": "^6.3.17",
+    "babel-loader": "6.2.0",
+    "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "babel-relay-plugin": "^0.6.0",
+    "classnames": "^2.2.1",
+    "express": "^4.13.3",
+    "express-graphql": "^0.4.5",
+    "graphql": "^0.4.14",
+    "graphql-relay": "^0.3.5",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "react-relay": "^0.6.0",
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   }
 }

--- a/scripts/updateSchema.js
+++ b/scripts/updateSchema.js
@@ -7,7 +7,7 @@ import { graphql }  from 'graphql';
 import { introspectionQuery, printSchema } from 'graphql/utilities';
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
-async () => {
+(async () => {
   var result = await (graphql(Schema, introspectionQuery));
   if (result.errors) {
     console.error(
@@ -20,7 +20,7 @@ async () => {
       JSON.stringify(result, null, 2)
     );
   }
-}();
+})();
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(

--- a/server.js
+++ b/server.js
@@ -29,7 +29,6 @@ var compiler = webpack({
         loader: 'babel',
         query: {
           plugins: ['./build/babelRelayPlugin'],
-          presets: ['es2015', 'stage-0','react'],
         },
         test: /\.js$/,
       }

--- a/server.js
+++ b/server.js
@@ -27,7 +27,10 @@ var compiler = webpack({
       {
         exclude: /node_modules/,
         loader: 'babel',
-        query: {stage: 0, plugins: ['./build/babelRelayPlugin']},
+        query: {
+          plugins: ['./build/babelRelayPlugin'],
+          presets: ['es2015', 'stage-0','react'],
+        },
         test: /\.js$/,
       }
     ]


### PR DESCRIPTION
- Upgrade all packages to their latest version
- Fix a non-stardard arrow function call syntax on updateSchema script
  () => {}() is not valid on es2015
- add babel presets: es2015, stage-0 and react
