### PR TITLE
Bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   "dependencies": {
     "babel": "5.8.21",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "^0.4.1",
+    "babel-relay-plugin": "^0.6.0",
     "classnames": "^2.1.3",
     "express": "^4.13.1",
-    "express-graphql": "^0.4.4",
-    "graphql": "^0.4.7",
-    "graphql-relay": "^0.3.3",
+    "express-graphql": "^0.4.5",
+    "graphql": "^0.4.14",
+    "graphql-relay": "^0.3.5",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react-relay": "^0.5.0",
-    "webpack": "^1.12.4",
-    "webpack-dev-server": "^1.10.1"
+    "react-relay": "^0.6.0",
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   }
 }


### PR DESCRIPTION
Bumps relay with babel-relay plugin to **0.6.0**, graphql, graphql-relay, express-graphql and webpack

Should I bump other deps ?
