### PR TITLE
Fix dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,22 +9,22 @@
     "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
-    "babel-core": "^6.3.17",
+    "babel-core": "6.3.17",
     "babel-loader": "6.2.0",
-    "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
-    "babel-relay-plugin": "^0.6.0",
-    "classnames": "^2.2.1",
-    "express": "^4.13.3",
-    "express-graphql": "^0.4.5",
-    "graphql": "^0.4.14",
-    "graphql-relay": "^0.3.5",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
-    "react-relay": "^0.6.0",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "babel-polyfill": "6.3.14",
+    "babel-preset-es2015": "6.3.13",
+    "babel-preset-react": "6.3.13",
+    "babel-preset-stage-0": "6.3.13",
+    "babel-relay-plugin": "0.6.0",
+    "classnames": "2.2.1",
+    "express": "4.13.3",
+    "express-graphql": "0.4.5",
+    "graphql": "0.4.14",
+    "graphql-relay": "0.3.5",
+    "react": "0.14.3",
+    "react-dom": "0.14.3",
+    "react-relay": "0.6.0",
+    "webpack": "1.12.9",
+    "webpack-dev-server": "1.14.0"
   }
 }


### PR DESCRIPTION
A new version of `babel-relay-plugin` broke `npm install` since some
dependencies were incompatible. Let's make the dependency versions fixed to
prevent breakage when other modules are updated. Explicit updates seem lower
friction that these breakages.

Fixes #53
