### PR TITLE
Update package.json to contain babel-cli (for dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "react-relay": "0.6.0",
     "webpack": "1.12.9",
     "webpack-dev-server": "1.14.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.3.17"
   }
 }


### PR DESCRIPTION
For people that don't have babel-cli installed, the _npm start' will throw an error regarding *babel-node ./server_
