### PR TITLE
Streamline the output of `WebpackDevServer`

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,16 @@ var app = new WebpackDevServer(compiler, {
   contentBase: '/public/',
   proxy: {'/graphql': `http://localhost:${GRAPHQL_PORT}`},
   publicPath: '/js/',
-  stats: {colors: true}
+  stats: {
+    colors: true,
+    hash: false,
+    timings: false,
+    assets: true,
+    chunks: false,
+    chunkModules: false,
+    modules: false,
+    children: true,
+  }
 });
 // Serve static resources
 app.use('/', express.static(path.resolve(__dirname, 'public')));


### PR DESCRIPTION
Streamline the output of `WebpackDevServer`

The current output of `WebpackDevServer` is too verbose. It fills up the whole console and buries useful logs inside. This PR change it to be something like the following:

```
Version: webpack 1.12.9
 Asset     Size  Chunks             Chunk Names
app.js  1.57 MB       0  [emitted]  main
webpack: bundle is now VALID.
```
