### PR TITLE
specifiy dependency on babel-cli in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "babel-core": "6.3.21",
+    "babel-cli": "^6.4.0",
     "babel-loader": "6.2.0",
     "babel-polyfill": "6.3.14",
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
updateSchema.js appears to expect babel-node, but it is not specified in package.json. `npm install`ing babel-cli makes this work for me.

```
>npm run update-schema

> relay-starter-kit@0.1.0 update-schema /home/brent/git/forks/relay-treasurehunt
> babel-node ./scripts/updateSchema.js

sh: 1: babel-node: not found

npm ERR! Linux 3.19.0-42-generic
npm ERR! argv "/home/brent/.nvm/versions/node/v4.1.1/bin/node" "/home/brent/.nvm/versions/node/v4.1.1/bin/npm" "run" "update-schema"
npm ERR! node v4.1.1
npm ERR! npm  v2.14.4
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! relay-starter-kit@0.1.0 update-schema: `babel-node ./scripts/updateSchema.js`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the relay-starter-kit@0.1.0 update-schema script 'babel-node ./scripts/updateSchema.js'.
npm ERR! This is most likely a problem with the relay-starter-kit package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     babel-node ./scripts/updateSchema.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls relay-starter-kit
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/brent/git/forks/relay-treasurehunt/npm-debug.log
```
