### PR TITLE
Fixes #60 - node queries now work out-of-the-box.

### DIFF
--- a/data/database.js
+++ b/data/database.js
@@ -8,8 +8,8 @@
  */
 
 // Model types
-class User extends Object {}
-class Widget extends Object {}
+class User {}
+class Widget {}
 
 // Mock data
 var viewer = new User();


### PR DESCRIPTION
Fixes #60, in which a lack of extension support in babel for builtin types caused any `obj instanceof User` checks to fail (`obj` would be in instance of `Object`), which made it impossible to query nodes ([object type resolver](https://github.com/relayjs/relay-starter-kit/blob/master/data/schema.js#L59) returned null).

This fix declares classes without explicitly extending the Object builtin type.

The following query now works out-of-the-box:

```
query {
  node(id: "V2lkZ2V0OjE=") {
    id
    ... on Widget {
      name
    }
  }
}
```
