### PR TITLE
Upgrade Relay & the Babel Relay plugin to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-preset-es2015": "6.5.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "0.7.0",
+    "babel-relay-plugin": "0.7.1",
     "classnames": "2.2.3",
     "express": "4.13.4",
     "express-graphql": "0.4.9",
@@ -23,7 +23,7 @@
     "graphql-relay": "0.3.6",
     "react": "0.14.7",
     "react-dom": "0.14.7",
-    "react-relay": "0.7.0",
+    "react-relay": "0.7.1",
     "webpack": "1.12.13",
     "webpack-dev-server": "1.14.1"
   },


### PR DESCRIPTION
Update "react-relay" and "babel-relay-plugin" versions.
    - react-relay from 0.7.0 to 0.7.1
    - babel-relay-plugin from 0.7.0 to 0.7.1

According to this thread: https://github.com/facebook/relay/issues/839 at version 0.7.0 we can't even doing a relay.setVariables indeed relay will construct a wrong graphql query under the hood (need ID! not ID).
