### PR TITLE
`Error: The (relay-query) Babel 5 plugin is being run with Babel 6` fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,33 @@
   "repository": "facebook/relay-starter-kit",
   "version": "0.1.0",
   "scripts": {
-    "start": "babel-node ./server.js",
-    "update-schema": "babel-node ./scripts/updateSchema.js"
+	"start": "./node_modules/babel-cli/bin/babel-node.js ./server.js",
+	"update-schema": "./node_modules/babel-cli/bin/babel-node.js scripts/updateSchema.js"
   },
   "dependencies": {
+    "babel": "^6.5.2",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-polyfill": "6.5.0",
+    "babel-preset-es2015": "6.5.0",
+    "babel-preset-react": "6.5.0",
+    "babel-preset-stage-0": "6.5.0",
+    "babel-relay-plugin": "0.7.3",
+    "classnames": "2.2.3",
+    "express": "4.13.4",
+    "express-graphql": "0.4.9",
+    "express-session": "^1.13.0",
+    "gcloud": "^0.27.0",
+    "graphql": "0.4.17",
+    "graphql-relay": "0.3.6",
+    "lodash": "^4.6.1",
+    "react": "0.14.7",
+    "react-dom": "0.14.7",
+    "react-relay": "0.7.3",
+    "webpack": "1.12.13",
+    "webpack-dev-server": "1.14.1"
+  },
+  "oldDependencies": {
     "babel-core": "^6.5.2",
     "babel-loader": "6.2.3",
     "babel-polyfill": "6.5.0",
@@ -26,8 +49,5 @@
     "react-relay": "0.7.3",
     "webpack": "1.12.13",
     "webpack-dev-server": "1.14.1"
-  },
-  "devDependencies": {
-    "babel-cli": "6.5.1"
   }
 }


### PR DESCRIPTION
Fixed `Error: The (relay-query) Babel 5 plugin is being run with Babel 6`
- added new babel version
- incorporated babel-cli inside the `node_modules`
- Google Cloud Engine compatible
