### PR TITLE
Fix output paths in Webpack config

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ function startAppServer(callback) {
         }
       ]
     },
-    output: {filename: 'app.js', path: '/'}
+    output: {filename: '/app.js', path: '/', publicPath: '/js/'}
   });
   appServer = new WebpackDevServer(compiler, {
     contentBase: '/public/',


### PR DESCRIPTION
This is needed to make code-splitting and async chunk loading work
