### PR TITLE
Use Relay.Renderer instead of Relay.RootContainer

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,9 +7,10 @@ import ReactDOM from 'react-dom';
 import Relay from 'react-relay';
 
 ReactDOM.render(
-  <Relay.RootContainer
-    Component={App}
-    route={new AppHomeRoute()}
+  <Relay.Renderer
+    environment={Relay.Store}
+    Container={App}
+    queryConfig={new AppHomeRoute()}
   />,
   document.getElementById('root')
 );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "0.9.1",
+    "babel-relay-plugin": "0.9.2",
     "chokidar": "1.5.1",
     "classnames": "2.2.5",
     "express": "4.13.4",
@@ -24,7 +24,7 @@
     "graphql-relay": "0.4.2",
     "react": "15.1.0",
     "react-dom": "15.1.0",
-    "react-relay": "0.9.1",
+    "react-relay": "0.9.2",
     "require-clean": "0.1.3",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"


### PR DESCRIPTION
Since `Relay.Renderer` has replaced `Relay.RootContainer` 👍  I also updated the `react-relay` and `babel-relay-plugin` to the latest version.
