### PR TITLE
Drop passPerPreset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,10 @@
 {
-  "passPerPreset": true,
   "presets": [
-    {
-      "plugins": [
-        "./build/babelRelayPlugin"
-      ]
-    },
-    "react",
     "es2015",
-    "stage-0"
+    "stage-0",
+    "react"
+  ],
+  "plugins": [
+    "./build/babelRelayPlugin"
   ]
 }


### PR DESCRIPTION
Babel plugin execution ordering is sufficient to ensure that the Relay transform runs before the template literal transform when used as follows. As such, specifying `passPerPreset` is unnecessary, and dropping it avoids a number of problems that arise when using `passPerPreset`.

We've been running like this for some time now, so we figured it'd be nicer to update documentation to reflect what should be current best practices.