### PR TITLE
Upgrades to Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "react-dom": "^15.3.1",
     "react-relay": "0.9.3",
     "require-clean": "0.1.3",
-    "webpack": "1.13.2",
-    "webpack-dev-server": "1.15.1"
+    "webpack": "2.5.1",
+    "webpack-dev-server": "2.4.5"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0"

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import {clean} from 'require-clean';
 import {exec} from 'child_process';
+import config from './webpack.config';
 
 const APP_PORT = 3000;
 const GRAPHQL_PORT = 8080;
@@ -15,19 +16,7 @@ let appServer;
 
 function startAppServer(callback) {
   // Serve the Relay app
-  const compiler = webpack({
-    entry: path.resolve(__dirname, 'js', 'app.js'),
-    module: {
-      loaders: [
-        {
-          exclude: /node_modules/,
-          loader: 'babel',
-          test: /\.js$/,
-        }
-      ]
-    },
-    output: {filename: '/app.js', path: '/', publicPath: '/js/'}
-  });
+  const compiler = webpack(config);
   appServer = new WebpackDevServer(compiler, {
     contentBase: '/public/',
     proxy: {'/graphql': `http://localhost:${GRAPHQL_PORT}`},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,28 @@
+import path from 'path';
+import webpack from 'webpack';
+
+const config = {
+  entry: path.resolve(__dirname, 'js', 'app.js'),
+  resolve: {
+    modules: [
+      "node_modules",
+      path.resolve(__dirname, "js")
+    ]
+  },
+  module: {
+    rules: [
+      {
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        test: /\.js$/
+      }
+    ]
+  },
+  output: {
+    filename: 'app.js',
+    path: '/',
+    publicPath: '/js/'
+  }
+};
+
+module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ const config = {
   entry: path.resolve(__dirname, 'js', 'app.js'),
   resolve: {
     modules: [
-      "node_modules",
-      path.resolve(__dirname, "js")
+      'node_modules',
+      path.resolve(__dirname, 'js'),
     ]
   },
   module: {


### PR DESCRIPTION
Hi!

I've been using relay-starter-kit for a while now, just to tinker about with how GraphQL and Relay works. I thought I'd migrate over one of the changes that I'd made locally. This change upgrades the version of Webpack to version 2, alongside extracting the configuration to its conventional location.