### PR TITLE
Mark repo as deprecated/unmaintained

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,34 @@
+# Relay Starter Kit
+
+This kit includes an app server, a GraphQL server implementing a tiny example schema, and a transpiler that you can use to get started building an app with Relay. For a walkthrough with a slightly larger schema, see the [Relay tutorial](https://facebook.github.io/relay/docs/tutorial.html).
+
+## Installation
+
+```
+npm install
+```
+
+## Running
+
+Start a local server:
+
+```
+npm start
+```
+
+## Developing
+
+Any changes you make to files in the `js/` directory will cause the server to
+automatically rebuild the app and refresh your browser.
+
+If at any time you make changes to `data/schema.js`, stop the server,
+regenerate `data/schema.json`, and restart the server:
+
+```
+npm run update-schema
+npm start
+```
+
+## License
+
+Relay Starter Kit is [BSD licensed](./LICENSE). We also provide an additional [patent grant](./PATENTS).

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ The contents of this repo are being conserved for historical interest only, but 
 ## Links
 
 - [Relay Modern documentation](https://facebook.github.io/relay/docs/relay-modern.html).
+- [Relay Modern examples](https://github.com/relayjs/relay-examples).
 - Original README.md file for this repo, now named [DOCUMENTATION.md](./DOCUMENTATION.md).

--- a/README.md
+++ b/README.md
@@ -1,34 +1,12 @@
-# Relay Starter Kit
+# DEPRECATED
 
-This kit includes an app server, a GraphQL server implementing a tiny example schema, and a transpiler that you can use to get started building an app with Relay. For a walkthrough with a slightly larger schema, see the [Relay tutorial](https://facebook.github.io/relay/docs/tutorial.html).
+## This repo is no longer actively maintained.
 
-## Installation
+This repo provided a basic starting point for building a "Relay Classic" (that is, Relay prior to version 1.0.0) application. All future development work is being undertaken on "Relay Modern" (version 1.0.0 and above).
 
-```
-npm install
-```
+The contents of this repo are being conserved for historical interest only, but we don't have any plans to update the code. If you'd like to get started with building a Relay Modern application, please see the link below. PRs to improve the documentation for the onboarding experience are welcome.
 
-## Running
+## Links
 
-Start a local server:
-
-```
-npm start
-```
-
-## Developing
-
-Any changes you make to files in the `js/` directory will cause the server to
-automatically rebuild the app and refresh your browser.
-
-If at any time you make changes to `data/schema.js`, stop the server,
-regenerate `data/schema.json`, and restart the server:
-
-```
-npm run update-schema
-npm start
-```
-
-## License
-
-Relay Starter Kit is [BSD licensed](./LICENSE). We also provide an additional [patent grant](./PATENTS).
+- [Relay Modern documentation](https://facebook.github.io/relay/docs/relay-modern.html).
+- Original README.md file for this repo, now named [DOCUMENTATION.md](./DOCUMENTATION.md).


### PR DESCRIPTION
For reasons noted in the new README.